### PR TITLE
Inject Services without Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.buildpath
-.project
-.settings/
-.DS_Store
+/vendor/
+composer.lock
+/phpunit.xml
+/tests/cache
+node_modules
+Resources/assets/node_modules

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,11 +19,6 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('jsvrcek_ics');
 
-        // bc layer for symfony/config 4.1 and older
-        if (false === \method_exists($treeBuilder, 'getRootNode')) {
-            $treeBuilder->root('jsvrcek_ics');
-        }
-
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.

--- a/DependencyInjection/JsvrcekIcsExtension.php
+++ b/DependencyInjection/JsvrcekIcsExtension.php
@@ -25,4 +25,9 @@ class JsvrcekIcsExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
     }
+
+    public function getAlias(): string
+    {
+        return 'jsvrcek_ics';
+    }
 }

--- a/README.md
+++ b/README.md
@@ -29,16 +29,34 @@ This bundle integrates the Jsvrcek\ICS library with the Symfony dependency injec
 you can instead, in your Symfony controller, use:
 
     namespace Acme\HelloBundle\Controller;
+    private Formatter $formatter;
+    private CalendarExport $calendarExport;
 
     class HelloController
     {
-        public function calendarAction()
+
+    public function __construct(Formatter $formatter, CalendarExport $calendarExport) {
+
+        $this->formatter = $formatter;
+        $this->calendarExport = $calendarExport;
+    }
+
+
+    // or inject them into the controller
+
+        public function calendarAction(Formatter $formatter, CalendarExport $calendarExport)
         {
-            $attendee = $this->get('jsvrcek_ics.model.relationship.attendee');
-            ...
-            
-            $calendarExport = $this->get('jsvrcek_ics.export');
-            ...
+        $eventOne = new CalendarEvent();
+        $eventOne->setStart(new \DateTime())
+            ->setSummary('Family reunion')
+            ->setUid('event-uid');
+
+        //add an Attendee
+        $attendee = new Attendee($this->formatter); // or $formatter
+        $attendee->setValue('moe@example.com')
+            ->setName('Moe Smith');
+        $eventOne->addAttendee($attendee);
+
             
             $response = new Response($calendarExport->getStream());
             $response->headers->set('Content-Type', 'text/calendar');

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Symfony Bundle providing dependency injection for the Jsvrcek\ICS library, which
 
 ## Installation
 
+composer config repositories.ics_bundle '{"type": "vcs", "url": "git@github.com:tacman/IcsBundle.git"}'
+composer req jsvrcek/ics-bundle:dev-tac
+
 Add on composer.json (see http://getcomposer.org/)
 
     "require" :  {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,31 +1,44 @@
 <?xml version="1.0" ?>
 
-<container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <container xmlns="http://symfony.com/schema/dic/services"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service shared="false" id="jsvrcek_ics.export" class="Jsvrcek\ICS\CalendarExport" public="true">
+
+
+        <service id="jsvrcek_ics.stream" class="Jsvrcek\ICS\CalendarStream" />
+        <service id="Jsvrcek\ICS\CalendarStream" alias="jsvrcek_ics.stream" />
+
+        <service id="jsvrcek_ics.utility.formatter" class="Jsvrcek\ICS\Utility\Formatter" public="true"/>
+        <service alias="jsvrcek_ics.utility.formatter" id="Jsvrcek\ICS\Utility\Formatter" />
+
+        <service id="jsvrcek_ics.export" class="Jsvrcek\ICS\CalendarExport" public="true" >
             <argument type="service" id="jsvrcek_ics.stream" />
             <argument type="service" id="jsvrcek_ics.utility.formatter" />
         </service>
-        <service shared="false" id="jsvrcek_ics.stream" class="Jsvrcek\ICS\CalendarStream"/>
-        <service shared="false" id="jsvrcek_ics.utility.formatter" class="Jsvrcek\ICS\Utility\Formatter"/>
 
-        <service shared="false" id="jsvrcek_ics.model.calendar" class="Jsvrcek\ICS\Model\Calendar"/>
-        <service shared="false" id="jsvrcek_ics.model.calendar_alarm" class="Jsvrcek\ICS\Model\CalendarAlarm"/>
-        <service shared="false" id="jsvrcek_ics.model.calendar_event" class="Jsvrcek\ICS\Model\CalendarEvent"/>
-        <service shared="false" id="jsvrcek_ics.model.calendar_free_busy" class="Jsvrcek\ICS\Model\CalendarFreeBusy"/>
-        <service shared="false" id="jsvrcek_ics.model.calendar_todo" class="Jsvrcek\ICS\Model\CalendarTodo"/>
-
-        <service shared="false" id="jsvrcek_ics.model.relationship.attendee" class="Jsvrcek\ICS\Model\Relationship\Attendee">
-        	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
-        </service>
-        <service shared="false" id="jsvrcek_ics.model.relationship.organizer" class="Jsvrcek\ICS\Model\Relationship\Organizer">
-        	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
+        <service id="Jsvrcek\ICS\CalendarExport" alias="jsvrcek_ics.export" public="false">
         </service>
 
-        <service shared="false" id="jsvrcek_ics.model.description.geo" class="Jsvrcek\ICS\Model\Description\Geo"/>
-        <service shared="false" id="jsvrcek_ics.model.description.location" class="Jsvrcek\ICS\Model\Description\Location"/>
+        <service id="jsvrcek_ics.model.calendar" class="Jsvrcek\ICS\Model\Calendar"/>
+        <service id="jsvrcek_ics.model.calendar_alarm" class="Jsvrcek\ICS\Model\CalendarAlarm"/>
+        <service id="jsvrcek_ics.model.calendar_event" class="Jsvrcek\ICS\Model\CalendarEvent"/>
+        <service id="jsvrcek_ics.model.calendar_free_busy" class="Jsvrcek\ICS\Model\CalendarFreeBusy"/>
+        <service id="jsvrcek_ics.model.calendar_todo" class="Jsvrcek\ICS\Model\CalendarTodo"/>
+
+        <service id="jsvrcek_ics.model.relationship.attendee" class="Jsvrcek\ICS\Model\Relationship\Attendee">
+        	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
+        </service>
+        <service id="jsvrcek_ics.model.relationship.organizer" class="Jsvrcek\ICS\Model\Relationship\Organizer">
+        	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
+        </service>
+
+        <service id="jsvrcek_ics.model.description.geo" class="Jsvrcek\ICS\Model\Description\Geo"/>
+        <service id="jsvrcek_ics.model.description.location" class="Jsvrcek\ICS\Model\Description\Location"/>
+
+
+
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,26 +5,26 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service shared="false" id="jsvrcek_ics.export" class="Jsvrcek\ICS\CalendarExport">
+        <service shared="false" id="jsvrcek_ics.export" class="Jsvrcek\ICS\CalendarExport" public="true">
             <argument type="service" id="jsvrcek_ics.stream" />
             <argument type="service" id="jsvrcek_ics.utility.formatter" />
         </service>
         <service shared="false" id="jsvrcek_ics.stream" class="Jsvrcek\ICS\CalendarStream"/>
         <service shared="false" id="jsvrcek_ics.utility.formatter" class="Jsvrcek\ICS\Utility\Formatter"/>
-        
+
         <service shared="false" id="jsvrcek_ics.model.calendar" class="Jsvrcek\ICS\Model\Calendar"/>
         <service shared="false" id="jsvrcek_ics.model.calendar_alarm" class="Jsvrcek\ICS\Model\CalendarAlarm"/>
         <service shared="false" id="jsvrcek_ics.model.calendar_event" class="Jsvrcek\ICS\Model\CalendarEvent"/>
         <service shared="false" id="jsvrcek_ics.model.calendar_free_busy" class="Jsvrcek\ICS\Model\CalendarFreeBusy"/>
         <service shared="false" id="jsvrcek_ics.model.calendar_todo" class="Jsvrcek\ICS\Model\CalendarTodo"/>
-        
+
         <service shared="false" id="jsvrcek_ics.model.relationship.attendee" class="Jsvrcek\ICS\Model\Relationship\Attendee">
         	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
         </service>
         <service shared="false" id="jsvrcek_ics.model.relationship.organizer" class="Jsvrcek\ICS\Model\Relationship\Organizer">
         	<argument type="service" id="jsvrcek_ics.utility.formatter"/>
         </service>
-        
+
         <service shared="false" id="jsvrcek_ics.model.description.geo" class="Jsvrcek\ICS\Model\Description\Geo"/>
         <service shared="false" id="jsvrcek_ics.model.description.location" class="Jsvrcek\ICS\Model\Description\Location"/>
     </services>

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,13 @@
         }
     ],
     "require":      {
+        "php": ">=7.4",
         "jsvrcek/ics":         		"~0.1",
-        "symfony/framework-bundle": ">=2.0"
+        "symfony/framework-bundle": ">=4.4"
     },
     "autoload":     {
-        "psr-0": { "Jsvrcek\\Bundle\\IcsBundle": "" }
+        "psr-4": { "Jsvrcek\\Bundle\\IcsBundle\\": "" }
     },
+
     "target-dir": "Jsvrcek/Bundle/IcsBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,5 @@
     },
     "autoload":     {
         "psr-4": { "Jsvrcek\\Bundle\\IcsBundle\\": "" }
-    },
-
-    "target-dir": "Jsvrcek/Bundle/IcsBundle"
+    }
 }


### PR DESCRIPTION
Since the container is no longer present in the controller, this PR refactors the services to have an alias so services can be injected by class name.

It also drops support for EOL Symfony and PHP.

The README now reflects the standard way of injecting services. 