### PR TITLE
[BUGFIX] Add compatibility with symfony/config 7.*

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('jsvrcek_ics');
 


### PR DESCRIPTION
In symfony/config 7.0 a return type was added to ConfigurationInterface::getConfigTreeBuilder. This lead to this error:

Fatal error: Declaration of Jsvrcek\Bundle\IcsBundle\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder in /var/www/vendor/jsvrcek/ics-bundle/DependencyInjection/Configuration.php on line 18